### PR TITLE
Add Tech for Palestine's ceasefire badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # community
 
+[![Ceasefire Now](https://badge.techforpalestine.org/default)](https://techforpalestine.org/learn-more)
+
 This repo is a place to decide upon common standards for the [Techies 4 Reproductive Justice](techies4rj.org) community. This includes security standards for community built software projects as well as standardizing how we infuse reproductive justice into our tech through values driven development.
 
 Core Contents


### PR DESCRIPTION
Tech for Palestine has badges for Github repos that call for ceasefire. This is a small thing we can add to our repo to call for Palestinian liberation. I think it's also fitting given that this is the repo where our values are documented.